### PR TITLE
Allow configuration for escaping content

### DIFF
--- a/s3lookup.py
+++ b/s3lookup.py
@@ -59,7 +59,7 @@ class S3LookupModule(object):
     def __init__(self, basedir=None, **kwargs):
         self.basedir = basedir
 
-    def run(self, terms, inject=None, **kwargs):
+    def run(self, terms, inject=None, escape=False, **kwargs):
         # XXX: messes with logging
         import ansible.utils
 
@@ -126,9 +126,10 @@ class S3LookupModule(object):
                         message=e.message,
                     )
                 )
-            # if there are newlines in the contents, they are not rendered
-            # correctly
-            contents = contents.encode('unicode-escape')
+            if escape:
+                # if there are newlines in the contents, they are not rendered
+                # correctly
+                contents = contents.encode('unicode-escape')
             # cache
             if self.cache is not None:
                 cache_key = self.cache_key(options['bucket'], key_name)


### PR DESCRIPTION
Addresses #4 - though I think this isn't the best solution. Hopefully solves the issue for @MrMMorris.

Due to the way citadel for ansible works, which is simply using `boto` to fetch the content of a key stored somewhere on Amazon's S3, sometimes the key might need to be escaped. Originally, the idea was to escape everything because if we didn't escape control characters, there might be weird rendering issues (i.e. htpasswd files, ssh private keys, etc.) where new lines matter.  This strategy, as I should've guessed doesn't work for everyone.

Example usage:

```python
{{ lookup('citadel', 'htpasswd/htpasswd', escape=True) | trim}}
```